### PR TITLE
Add support for overriding discovered PRs

### DIFF
--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -427,6 +427,10 @@ class Gren {
             return this._getMergedPullRequests(since, page + 1).then(prsResults => prsResults.concat(filterPrs));
         }
 
+        if (typeof this.options.overridePrs === 'function') {
+            return this.options.overridePrs(prs);
+        }
+
         return filterPrs;
     }
 


### PR DESCRIPTION
Sometimes there is a desire to include PRs in the changelog that aren't discoverable via the GitHub APIs. One example of this is PRs that are merged as part of a security fix. This will allow adding a function that returns an array of PRs to be used instead of the ones returned from the GitHub API. The function is passed the API-discovered PRs, which allows for mutation or augmentation. These PRs are injected into the workflow before date filtering and ordering takes place.