### PR TITLE
Use application version number for head of changelog

### DIFF
--- a/lib/src/Gren.js
+++ b/lib/src/Gren.js
@@ -59,6 +59,7 @@ class Gren {
         this.options.ignoreIssuesWith = utils.convertStringToArray(ignoreIssuesWith);
         this.options.ignoreCommitsWith = utils.convertStringToArray(ignoreCommitsWith);
         this.options.ignoreTagsWith = utils.convertStringToArray(ignoreTagsWith);
+        this.options.version = this.options.version || utils.findRelevantVersion();
 
         if (limit && limit > 0 && limit <= MAX_TAGS_LIMIT) {
             this.options.limit = limit;
@@ -1104,7 +1105,7 @@ class Gren {
         if (this.options.head != null) {
             const latest = [{
                 ...sortedReleaseDates[0],
-                name: this.options.head,
+                name: this.options.version,
                 date: (new Date()).toISOString()
             },
             {
@@ -1154,12 +1155,23 @@ class Gren {
         for (const releaseRange of releaseRanges) {
             let commits;
             if (releaseRange[1].name != null) {
+                let response;
+                try {
+                    response = await this.repo.compareBranches(
+                        releaseRange[1].name,
+                        releaseRange[0].name
+                    );
+                } catch {
+                    // If the above failed, it is because we are using a calculated version as the first `name`
+                    // Use the head of the branch instead
+                    response = await this.repo.compareBranches(
+                        releaseRange[1].name,
+                        this.options.head
+                    );
+                }
                 ({
                     data: { commits }
-                } = await this.repo.compareBranches(
-                    releaseRange[1].name,
-                    releaseRange[0].name
-                ));
+                } = response);
             } else {
                 ({ data: commits } = await this.repo.listCommits({
                     since: releaseRange[1].date,

--- a/lib/src/_utils.js
+++ b/lib/src/_utils.js
@@ -1,5 +1,6 @@
 const chalk = require('chalk');
 const fs = require('fs');
+const path = require('path');
 const ora = require('ora');
 const YAML = require('json2yaml');
 const Path = require('path');
@@ -361,6 +362,44 @@ function getGrenConfig(path, ...args) {
 }
 
 /**
+ * Look at the `package.json` and try to get the version of the current program
+ * If that fails, return the version of this package
+ *
+ * @returns {string} The version of the current package
+ */
+function findRelevantVersion() {
+    const startPath = __dirname;
+    let currentPath = startPath;
+    let lastVersion = null;
+    let passedNodeModules = false;
+
+    while (true) {
+        const dirName = path.basename(currentPath);
+
+        if (dirName === 'node_modules') {
+            passedNodeModules = true;
+        } else {
+            const packageJsonPath = path.join(currentPath, 'package.json');
+            if (fs.existsSync(packageJsonPath)) {
+                lastVersion = require(packageJsonPath).version;
+                if (passedNodeModules) {
+                    break;
+                }
+            }
+        }
+
+        const newPath = path.resolve(currentPath, '..');
+        if (newPath === currentPath) {
+            break; // We're at the root and can't go any higher
+        }
+
+        currentPath = newPath;
+    }
+
+    return lastVersion;
+}
+
+/**
  * Just a noop function
  */
 function noop() {}
@@ -385,5 +424,6 @@ module.exports = {
     requireConfig,
     sortObject,
     task,
-    writeConfigToFile
+    writeConfigToFile,
+    findRelevantVersion
 };


### PR DESCRIPTION
In order to better support tools like `release-it`, change the first entry in the changelog to use the version number from `package.json` instead of the branch name. This can be overridden via a configuration option. The branch name is still used as HEAD to make sure all commits since the last tag are included in the changelog.